### PR TITLE
[31기 홍두현] add: 공통영역 header, modal 팝업 스타일 수정

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -52,7 +52,7 @@ const Nav = () => {
           <button type="button" className="btn-profile">
             프로필
           </button>
-          <ul className="profile-modal active">
+          <ul className="profile-modal">
             <li className="modal-profile">프로필</li>
             <li className="modal-save">저장됨</li>
             <li className="modal-setting">설정</li>

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -7,6 +7,7 @@
   width: 100%;
   border-bottom: 1px solid #e9e9e9;
   background: #fff;
+  z-index: 100;
 
   .header-wrap {
     display: flex;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- aside를 fixed나 absolute로 잡은 스타일을 위한 공통영역 header, modal 스타일 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- instagram과 비슷하게 스크롤 했을 때 메인 피드 옆 aside 부분을 스크롤이 되어도 고정 되도록 수정을 하기 위해 header에 스타일을 수정했습니다.
- modal 팝업에 z-index 값을 사용해서 화면상에서의 우선 순위를 줬는데 header에도 fixed로 되어있어서 modal의 최상위 부모인 header에게z-index 값을 주었습니다.


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- z-index를 사용하는 시점과 사용하는 태그의 위치를 좀 더 파악하게 되었습니다.

<br />

## :: 기타 질문 및 특이 사항

